### PR TITLE
Update dist. used when running build on TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: csharp
+dist: trusty
 sudo: required
 mono: none
 dotnet: 1.0.0-preview2-003121


### PR DESCRIPTION
Previous behavior would not run due to unsupported platform related to .NET Core (i.e. Ubuntu 12.04).
New behavior should use 14.04.
